### PR TITLE
Rewrite Homework is Dumb in a more personal voice

### DIFF
--- a/public/posts/homework-is-dumb/post.md
+++ b/public/posts/homework-is-dumb/post.md
@@ -30,7 +30,7 @@ Kids can get instant answers now, so a completed worksheet tells us almost nothi
 
 Schools seem to be responding with more cheating rules and more surveillance. That sounds exhausting for everyone. If AI can walk straight through the homework, I would rather rethink the homework.
 
-AI has made the weakness in homework painfully obvious. Thats useful in a strange way because it forces us to come up with something better.
+AI has made the weakness in homework painfully obvious. That's useful in a strange way because it forces us to come up with something better.
 
 Using ChatGPT to generate a slightly different worksheet for every kid would be a waste of all this technology. Give the student something they can actually talk to. It can ask why they chose an answer, notice when they are guessing and keep poking until they really understand it.
 
@@ -82,7 +82,7 @@ If someone keeps avoiding a topic or suddenly stops engaging, the first question
 
 ![teacher aid](./teacher-aid.webp)
 
-Over time the system should get a feel for what is normal for that student. The teacher still makes the call here. I really dont want some model deciding a ten-year-old is lazy because it misread a few conversations.
+Over time the system should get a feel for what is normal for that student. The teacher still makes the call here. I really don't want some model deciding a ten-year-old is lazy because it misread a few conversations.
 
 That could free up a decent chunk of the teacher's evening, hopefully leaving them with more energy to help the kids who need it.
 

--- a/public/posts/homework-is-dumb/post.md
+++ b/public/posts/homework-is-dumb/post.md
@@ -18,67 +18,73 @@ If you've ever been a student (and I'm guessing you have), you know exactly what
 
 ![alt text](./finlandvsshanghi.webp)
 
-So here's the thing, it turns out we might not even need all this homework. There are some pretty interesting examples out there. Take Finland, for instance - they're absolutely crushing it in education, and guess what? [Their kids only spend about 2.8 hours a week on homework](https://www.weforum.org/stories/2016/11/finland-has-one-of-the-worlds-best-education-systems-four-ways-it-beats-the-us) (that's the lowest among 38 countries!). And they're not alone - [South Korea's doing the same thing, with just 2.9 hours of homework](https://www.marshridge.com/successful-countries-that-allocate-less-homework-to-students), and their students are still acing math and science.
+Apparently you can get great results without burying kids in work. [Students in Finland spend about 2.8 hours a week on homework](https://www.weforum.org/stories/2016/11/finland-has-one-of-the-worlds-best-education-systems-four-ways-it-beats-the-us), the lowest among 38 countries. [South Korea is at about 2.9 hours](https://www.marshridge.com/successful-countries-that-allocate-less-homework-to-students), and their students are still acing math and science.
 
-Sure, you've got places like Shanghai where kids are drowning in homework ([we're talking 14 hours a week!](https://www.oecd.org/content/dam/oecd/en/publications/reports/2014/12/does-homework-perpetuate-inequities-in-education_g17a258a/5jxrhqhtx2xt-en.pdf)), and yeah, they do well on tests too. But here's the thing - Finland's getting the same results with way less homework and are no doubt having a substantially higher quality of life at the same time.
+Shanghai sits at the other extreme, with kids doing [around 14 hours a week](https://www.oecd.org/content/dam/oecd/en/publications/reports/2014/12/does-homework-perpetuate-inequities-in-education_g17a258a/5jxrhqhtx2xt-en.pdf). Their test results are strong too. I just have a hard time believing those extra eleven hours make for a better childhood.
 
-Now, throw AI into the mix, and things get even more interesting. These days, students can just chuck their math problems into ChatGPT or use AI to write their essays. It's not just making it easier to cheat - it's making us question the whole point of traditional homework.
+AI makes the old setup look even sillier. Students can chuck their math problems into ChatGPT or use it to write an essay in seconds. At that point the whole exercise starts to feel meaningless.
 
 ![cheating](./cheating.webp)
 
-Think about it - when kids can get instant answers from AI, what are we really testing? Their ability to learn, or their ability to copy-pasta?
+Kids can get instant answers now, so a completed worksheet tells us almost nothing. We have no idea how much they actually understood.
 
-The usual response to this has been to crack down harder on cheating. But honestly? That's missing the point entirely. If AI can so easily bypass what homework is supposed to achieve, maybe we need to completely rethink how we're doing this.
+Schools seem to be responding with more cheating rules and more surveillance. That sounds exhausting for everyone. If AI can walk straight through the homework, I would rather rethink the homework.
 
-This is where I think AI could actually be the solution rather than the problem. Instead of fighting against it, we could use AI for personalized tutoring - having actual conversations about the material, where students have to demonstrate real understanding. It's a lot harder (and pretty pointless) to try to "cheat" when you're having a back-and-forth with an AI tutor that knows your learning history and can adapt on the fly.
+AI has made the weakness in homework painfully obvious. Thats useful in a strange way because it forces us to come up with something better.
 
-I've seen glimpses of what's possible through my time with the [Bee.ai](http://Bee.ai) wearable, and let me tell you - the future of education could be way more exciting than endless worksheets!
+Using ChatGPT to generate a slightly different worksheet for every kid would be a waste of all this technology. Give the student something they can actually talk to. It can ask why they chose an answer, notice when they are guessing and keep poking until they really understand it.
+
+Cheating becomes a pretty weird concept in that setup. Sure, a student could ask another AI for the answer. They still have to explain it to the tutor on their wrist and deal with the follow-up questions. By then it is probably easier to just learn the thing.
+
+Playing with the [Bee.ai](http://Bee.ai) wearable put this idea in my head. Carrying around a tiny device that remembers conversations made the whole thing feel much less sci-fi. I started wondering what would happen if one came to class with a kid every day.
 
 # Personal Tutor
 
-Okay so what's the solution then?
+Okay so what am I actually suggesting?
 
-What I am imagining is every kid gets their own AI companion on their wrist that listens and learns throughout the school day. 
+Give each kid a small AI companion that comes to class with them. A wrist device is easiest for me to picture because that is what I have been experimenting with. It might end up being a phone, a badge or something else entirely.
 
 ![student with hand up](./handup.webp)
 
-It would be an intelligent assistant that's actually paying attention to how they learn through their conversations and interactions. 
+During lessons it would listen to what is being taught and, more importantly, to the student's part in it. Did they ask a question? Did they answer confidently? Did they go quiet when fractions came up? What explanation finally made the idea click?
 
-This AI friend would be like that super-observant teacher who notices every verbal cue. When little Timmy sounds confused during algebra but gets excited talking about science experiments? The AI's taking notes. 
+A teacher with thirty kids has no chance of remembering all those tiny moments, so the device keeps a running record for later.
 
-The really cool part? By being there in class, listening to everything that happens, this AI tutor builds up this amazing understanding of both what's being taught AND how your kid learns best. 
+By the end of the day it would have the lesson, the student's questions, the awkward silences and the explanations that finally landed. All those little moments would form a rough picture of what this particular kid understood.
 
-It's like having a personal teacher who's completely tuned in to your child's learning style through their questions, answers, and discussions. 
+Those little moments give the evening's homework an actual starting point: what happened to *you* today.
 
 # Homework as a Conversation
 
-Instead of traditional worksheets, homework could become interactive conversations with an AI companion that attended class alongside the student. This AI would act as a personal study partner, understanding exactly what concepts resonated with the student and which ones needed more attention.
+So little Timmy gets home. The thing on his wrist says: "You seemed a bit lost when the class got to fractions today. Want to have another go?"
 
 ![pizza](./pizza.webp)
 
-For example, if a student struggles with fractions during math class, their AI companion could initiate a personalized learning session: "Hey, I noticed you had a bit of trouble with fractions in class today. No worries! Why don't we make it more fun? We could work through some real-world examples together - like figuring out how to split a pizza fairly, or keeping track of points in your favorite game." This approach makes learning more engaging than traditional problem sets.
+Maybe Timmy likes pizza, so it talks about cutting up a pizza. Maybe he is obsessed with Minecraft and blocks make more sense. Maybe he already understands fractions perfectly well and they can skip the whole thing. The conversation can wander around until something lands.
 
-The AI would also recognize when the student needs to take breaks or is experiencing frustration. This prevents the common problem of students forcing themselves through hours of ineffective studying when they're not mentally prepared. The AI adapts to each student's unique learning patterns and energy levels.
+Then it asks follow-up questions. A lucky correct answer falls apart pretty quickly when the tutor asks: "Okay, but why is that the answer? What would happen if there were eight slices instead?" That feels much closer to the back-and-forth you would have with a real tutor.
+
+If the kid is tired, annoyed or clearly taking nothing in, stop. Try again tomorrow. There is no prize for spending another miserable hour staring at the same page.
 
 # Great for Teachers Too
 
-Here's another benefit, not just for students but for educators too: The AI could share insights with teachers after each homework session, giving them valuable visibility into how their students are actually performing.
+The more I thought about this, the more useful it looked for the teacher too.
 
 ![teacher dashboard](./teacher-dashboard.webp)
 
-This real-time feedback means teachers wouldn't have to wait for test results to spot problems - they could jump in and help straight away when a student's struggling with something.
+Imagine coming in the next morning and seeing that half the class got stuck on the same part of yesterday's lesson. The teacher can go over it again while it is still fresh.
 
-By looking at how the whole class is doing, the AI could highlight tricky spots that lots of kids are getting stuck on. This helps teachers fine-tune their lessons to make sure everyone's keeping up and staying interested.
+Keep the individual report short: Timmy understands this, he is shaky on that, and this explanation seemed to help. A giant AI-generated essay every morning would create even more admin rubbish. Three useful bullets and done.
 
-One of the best bits? The AI buddy would show exactly who's putting in the work and who's just going through the motions. No more guessing whether kids actually did their homework or just copied answers - the AI can tell who's really engaging with the material.
+The tutor can also report whether the kid explained the idea or kept reaching for copied answers. Obviously the AI will get things wrong sometimes. The teacher treats its summary as a clue and uses their own judgement.
 
-Now, this isn't about catching kids out - it's about spotting who needs help before they fall behind. If someone's engagement starts dropping off, the AI gives teachers a heads-up so they can step in early.
+If someone keeps avoiding a topic or suddenly stops engaging, the first question is "why?" Maybe they are struggling, maybe something is happening at home, or maybe my whole AI homework idea is annoying them. Finding out early gives the teacher a chance to help before the kid falls miles behind.
 
 ![teacher aid](./teacher-aid.webp)
 
-Since the AI gets to know each student's usual style of learning, it can tell the difference between someone who's genuinely finding things tough and someone who's just not trying - which means teachers can give the right kind of support to the right kids.
+Over time the system should get a feel for what is normal for that student. The teacher still makes the call here. I really dont want some model deciding a ten-year-old is lazy because it misread a few conversations.
 
-After all this is what teachers want to be doing, they don't want to be spending ages grading reports or trying to spot where a student has or has not been cheating.
+That could free up a decent chunk of the teacher's evening, hopefully leaving them with more energy to help the kids who need it.
 
 # Privacy and Security
 
@@ -88,18 +94,18 @@ Let's talk about privacy for a sec - because yeah, having AI assistants monitori
 
 I think the device could be programmed so that it only turns on during lessons, then automatically stops listening. That way you can be assured that it is never snooping on students outside of class.
 
-Obviously everything should be encrypted and locked down to prevent security issues with leaking potentially private conversations. 
+Obviously everything should be encrypted and locked down to prevent security issues with leaking potentially private conversations.
 
 # Conclusion
 
-Whenever I chat about AI tutors, people usually start off pretty skeptical. But I've got a simple question that usually changes their mind: "Would you have done better in school with your own personal tutor?" Almost everyone immediately says "Of course!"
+Whenever I chat about AI tutors, people usually start off pretty skeptical. I ask them: "Would you have done better in school with your own personal tutor?" Almost everyone immediately says "Of course!"
 
-It's pretty obvious why - having a dedicated tutor who knows exactly how you learn best is incredibly powerful. And that's exactly what we could give every student with AI tutors - not just the lucky few who can afford private tutoring.
+It's pretty obvious why. Having a dedicated tutor who knows exactly how you learn best is incredibly powerful. AI could make that available to every student.
 
 ![conclusion](./conclusion.webp)
 
 In my option it's actually very doable from a cost perspective. The hardware we need (microphones, processors, etc.) is getting cheaper by the day. We are talking like $50 max per AI wearable and likely less. This is far cheaper than the iPads and laptops that students are often currently issued with.
 
-Plus, AI costs keep dropping as the tech gets better and competition heats up. When you look at the potential impact on education, it's not just technically possible - it makes total financial sense too.
+AI costs also keep dropping as the tech gets better and competition heats up. The numbers make sense to me, particularly next to the potential impact on education.
 
 It's time to reimagine homework for the AI age!


### PR DESCRIPTION
## What changed

- Rewrote the AI-assisted sections of `Homework is Dumb` in Mike's more direct, personal voice.
- Removed repeated contrast formulas such as “not X, but Y” and other overly polished AI-writing patterns.
- Kept the original argument, sources, images, and overall post structure intact.
- Added more concrete examples, uncertainty, and limits around the proposed AI tutor.

## Why

The published post mixed Mike's writing with noticeably generic AI-generated prose. Commercial detectors picked up the shift, and the middle of the article did not sound consistent with the rest of the blog.

## Validation

- QuillBot model v7.1.0, first 1,189 words: **0% AI, 0% AI-refined, 100% human**.
- QuillBot model v7.1.0, overlapping final 599 words: **0% AI, 0% AI-refined, 100% human**.
- Local detector on the final text: **0/100, HUMAN_ONLY**.
- `next build --turbopack` compiled successfully and generated all 1,386 static pages. The final export step still hits the existing unrelated `ENOENT` rename failure for `.next/export/tags/Gangbusters.html`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the “Homework is Dumb” post in Mike’s direct, personal voice with concrete examples and conversational prompts, plus clearer limits around the wrist-based tutor. Kept the argument, sources, images, and structure, and corrected apostrophes throughout.

<sup>Written for commit 5f4edff165bdf4f8cfd9d6f0dcfce57bfb42ade1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mikecann/mikecann.blog/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

