### PR TITLE
Delay new post emails until after deploys

### DIFF
--- a/convex/blogPosts/admin/actions.test.ts
+++ b/convex/blogPosts/admin/actions.test.ts
@@ -4,6 +4,7 @@ import { api } from "../../_generated/api";
 import schema from "../../schema";
 import { EntryId } from "@convex-dev/rag";
 import { v } from "convex/values";
+import { NEW_POST_EMAIL_DELAY_MS } from "../../mailchimp/constants";
 
 // Mock the environment variable
 const originalEnv = process.env;
@@ -112,6 +113,15 @@ describe("upsert action", () => {
       attempts: 0,
     });
     expect(emailCampaign?.scheduledFunctionId).toBeDefined();
+
+    const scheduledFunction = await t.run(async (ctx) => {
+      return await ctx.db.system.get(emailCampaign!.scheduledFunctionId!);
+    });
+
+    expect(scheduledFunction).toMatchObject({
+      state: { kind: "pending" },
+      scheduledTime: Date.now() + NEW_POST_EMAIL_DELAY_MS,
+    });
   });
 
   test("updates existing blog post when ragEntryId changes", async () => {

--- a/convex/blogPosts/internal/mutations.ts
+++ b/convex/blogPosts/internal/mutations.ts
@@ -3,6 +3,7 @@ import { convex } from "../../builder";
 import { ensureFP } from "../../../essentials/misc/ensure";
 import { vEntryId } from "@convex-dev/rag";
 import { internal } from "../../_generated/api";
+import { NEW_POST_EMAIL_DELAY_MS } from "../../mailchimp/constants";
 
 export const createBlogPost = convex
   .mutation()
@@ -30,7 +31,7 @@ export const createBlogPost = convex
     );
 
     const scheduledFunctionId = await ctx.scheduler.runAfter(
-      0,
+      NEW_POST_EMAIL_DELAY_MS,
       internal.mailchimp.internal.actions.sendNewPostCampaign,
       {
         campaignId,

--- a/convex/mailchimp/constants.ts
+++ b/convex/mailchimp/constants.ts
@@ -1,4 +1,4 @@
 // Give the production site time to finish deploying before subscribers receive
 // links to a newly created post. Production deploys currently take around seven
-// minutes, so fifteen minutes leaves a useful safety margin.
-export const NEW_POST_EMAIL_DELAY_MS = 15 * 60 * 1000;
+// minutes, so thirty minutes leaves a generous safety margin.
+export const NEW_POST_EMAIL_DELAY_MS = 30 * 60 * 1000;

--- a/convex/mailchimp/constants.ts
+++ b/convex/mailchimp/constants.ts
@@ -1,0 +1,4 @@
+// Give the production site time to finish deploying before subscribers receive
+// links to a newly created post. Production deploys currently take around seven
+// minutes, so fifteen minutes leaves a useful safety margin.
+export const NEW_POST_EMAIL_DELAY_MS = 15 * 60 * 1000;

--- a/scripts/postEmailCampaignStatus.test.ts
+++ b/scripts/postEmailCampaignStatus.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import type { Id } from "../convex/_generated/dataModel";
 import { isPostEmailCampaignScheduledOrSent } from "./postEmailCampaignStatus";
 
 describe("isPostEmailCampaignScheduledOrSent", () => {
@@ -6,7 +7,7 @@ describe("isPostEmailCampaignScheduledOrSent", () => {
     expect(
       isPostEmailCampaignScheduledOrSent({
         status: "queued",
-        scheduledFunctionId: "scheduled-function-id",
+        scheduledFunctionId: "scheduled-function-id" as Id<"_scheduled_functions">,
       }),
     ).toBe(true);
   });

--- a/scripts/postEmailCampaignStatus.test.ts
+++ b/scripts/postEmailCampaignStatus.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { isPostEmailCampaignScheduledOrSent } from "./postEmailCampaignStatus";
+
+describe("isPostEmailCampaignScheduledOrSent", () => {
+  test("accepts a queued campaign with a durable scheduled function", () => {
+    expect(
+      isPostEmailCampaignScheduledOrSent({
+        status: "queued",
+        scheduledFunctionId: "scheduled-function-id",
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects a queued campaign before its scheduled function is attached", () => {
+    expect(isPostEmailCampaignScheduledOrSent({ status: "queued" })).toBe(false);
+  });
+
+  test("accepts a campaign that has already been sent", () => {
+    expect(isPostEmailCampaignScheduledOrSent({ status: "sent" })).toBe(true);
+  });
+
+  test.each(["creating_campaign", "content_set", "sending", "failed"])(
+    "does not treat %s as safely scheduled",
+    (status) => {
+      expect(isPostEmailCampaignScheduledOrSent({ status })).toBe(false);
+    },
+  );
+});

--- a/scripts/postEmailCampaignStatus.ts
+++ b/scripts/postEmailCampaignStatus.ts
@@ -1,0 +1,10 @@
+type PostEmailCampaignStatus = {
+  status: string;
+  scheduledFunctionId?: unknown;
+};
+
+export function isPostEmailCampaignScheduledOrSent(campaign: PostEmailCampaignStatus): boolean {
+  if (campaign.status === "sent") return true;
+
+  return campaign.status === "queued" && campaign.scheduledFunctionId != null;
+}

--- a/scripts/postEmailCampaignStatus.ts
+++ b/scripts/postEmailCampaignStatus.ts
@@ -1,7 +1,9 @@
-type PostEmailCampaignStatus = {
-  status: string;
-  scheduledFunctionId?: unknown;
-};
+import type { Doc } from "../convex/_generated/dataModel";
+
+type PostEmailCampaignStatus = Pick<
+  Doc<"postEmailCampaigns">,
+  "status" | "scheduledFunctionId"
+>;
 
 export function isPostEmailCampaignScheduledOrSent(campaign: PostEmailCampaignStatus): boolean {
   if (campaign.status === "sent") return true;

--- a/scripts/uploadPostsToConvex.ts
+++ b/scripts/uploadPostsToConvex.ts
@@ -7,6 +7,7 @@ import { ConvexHttpClient } from "convex/browser";
 import { ensure } from "../essentials/misc/ensure";
 import { hashContent } from "../utils/hashing";
 import pLimit from "p-limit";
+import { isPostEmailCampaignScheduledOrSent } from "./postEmailCampaignStatus";
 
 const token = ensure(process.env.BLOG_POST_ADMIN_TOKEN, "Missing env BLOG_POST_ADMIN_TOKEN");
 
@@ -95,9 +96,11 @@ async function verifyNewPostEmails(slugs: string[]) {
 
     const missing = rows.filter((row) => !row.campaign);
     const failed = rows.filter((row) => row.campaign?.status === "failed");
-    const pending = rows.filter((row) =>
-      row.campaign ? !["sent", "failed"].includes(row.campaign.status) : true,
-    );
+    const pending = rows.filter((row) => {
+      if (!row.campaign) return true;
+      if (row.campaign.status === "failed") return false;
+      return !isPostEmailCampaignScheduledOrSent(row.campaign);
+    });
 
     if (failed.length > 0) {
       const details = failed
@@ -108,7 +111,8 @@ async function verifyNewPostEmails(slugs: string[]) {
 
     if (missing.length === 0 && pending.length === 0) {
       for (const row of rows) {
-        console.log(`Mailchimp email sent for '${row.slug}'`);
+        const message = row.campaign?.status === "sent" ? "sent" : "scheduled";
+        console.log(`Mailchimp email ${message} for '${row.slug}'`);
       }
       return;
     }


### PR DESCRIPTION
## Why

The latest post email went out while the production deployment was still running. Algolia already knew about the post, so visitors who opened the newsletter link hit the 404 page and were redirected back to the same unavailable URL in a loop.

A production deployment took about seven minutes. Delaying new-post emails by 15 minutes gives the site time to become available before subscribers receive the link.

## What changed

- Schedule newly created post campaigns 15 minutes after upload instead of immediately.
- Keep failed-campaign retries immediate.
- Treat a queued campaign with a durable Convex scheduled-function ID as successfully scheduled, so the deployment does not wait 15 minutes before completing.
- Add coverage for the delay and deployment verification states.

No Convex schema changes are included.

## Verification

- bunx tsc --noEmit
- bun run test, 35 tests passed
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delay new-post Mailchimp emails by 30 minutes to avoid 404s during production deploys. Deployment verification now treats queued campaigns with a durable scheduled-function ID as scheduled.

- **Bug Fixes**
  - Schedule new-post campaigns 30 minutes after upload via `NEW_POST_EMAIL_DELAY_MS`; retries remain immediate.
  - Treat queued campaigns with a scheduled-function ID as successfully scheduled to prevent deploy waits; update script logs “sent” vs “scheduled.”
  - Add `isPostEmailCampaignScheduledOrSent` with tests; tighten types using Convex `Doc<"postEmailCampaigns">`; verify scheduled time in the scheduler.

<sup>Written for commit d816d90f7d84ac985467caada88d057bf768063a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mikecann/mikecann.blog/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

